### PR TITLE
 refactor: simplify cancellation, notifications, browser lifecycle, and HTTP requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - new
+  pull_request:
+    branches:
+      - dev
+      - new
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  quality:
+    name: Lint and type check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run Ruff
+        run: ruff check src tests
+
+      - name: Run mypy
+        run: mypy src
+
+  tests:
+    name: Test on Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  build:
+    name: Build distributions
+    needs:
+      - quality
+      - tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke test built wheel
+        run: |
+          python -m venv "$RUNNER_TEMP/wheel-smoke"
+          "$RUNNER_TEMP/wheel-smoke/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/wheel-smoke/bin/python" -m pip install dist/*.whl
+          "$RUNNER_TEMP/wheel-smoke/bin/ynu-spider" --help
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-distributions-${{ github.sha }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,242 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  validate:
+    name: Validate release source
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tagged commit is on the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          default_ref="refs/remotes/origin/$DEFAULT_BRANCH"
+
+          if ! git show-ref --verify --quiet "$default_ref"; then
+            echo "Default branch ref is unavailable: $default_ref" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "$default_ref"; then
+            echo "Release commit must be merged into $DEFAULT_BRANCH before tagging" >&2
+            exit 1
+          fi
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag and package versions
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          package_version = pyproject["project"]["version"]
+
+          init_source = Path("src/ynu_xk_spider/__init__.py").read_text(
+              encoding="utf-8"
+          )
+          match = re.search(
+              r'^__version__\s*=\s*["\']([^"\']+)["\']',
+              init_source,
+              re.MULTILINE,
+          )
+          if match is None:
+              raise SystemExit("Unable to read __version__ from package")
+
+          module_version = match.group(1)
+          release_tag = os.environ["RELEASE_TAG"]
+          expected_tag = f"v{package_version}"
+
+          if module_version != package_version:
+              raise SystemExit(
+                  "Version mismatch: "
+                  f"pyproject.toml={package_version}, __init__.py={module_version}"
+              )
+          if release_tag != expected_tag:
+              raise SystemExit(
+                  f"Tag mismatch: expected {expected_tag}, received {release_tag}"
+              )
+
+          print(f"Validated release {release_tag}")
+          PY
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run Ruff
+        run: ruff check src tests
+
+      - name: Run mypy
+        run: mypy src
+
+  tests:
+    name: Test release on Python ${{ matrix.python }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  build:
+    name: Build release distributions
+    needs:
+      - validate
+      - tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke test built wheel
+        run: |
+          python -m venv "$RUNNER_TEMP/release-smoke"
+          "$RUNNER_TEMP/release-smoke/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/release-smoke/bin/python" -m pip install dist/*.whl
+          "$RUNNER_TEMP/release-smoke/bin/ynu-spider" --help
+
+      - name: Upload release distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
+  github_release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read # Download the verified artifact produced by this workflow.
+      contents: write # Create the GitHub Release and upload its assets.
+
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-distributions
+          path: dist
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/* \
+              --clobber \
+              --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$RELEASE_TAG" dist/* \
+              --generate-notes \
+              --title "$RELEASE_TAG" \
+              --verify-tag \
+              --repo "$GITHUB_REPOSITORY"
+          fi
+
+  publish_pypi:
+    name: Publish to PyPI
+    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
+    needs:
+      - build
+      - github_release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ynu-xk-spider/
+    permissions:
+      actions: read # Download the verified artifact produced by this workflow.
+      contents: read # Retain the workflow's default read-only repository access.
+      id-token: write # Exchange GitHub's OIDC identity for a short-lived PyPI token.
+
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-distributions
+          path: dist
+
+      - name: Publish distributions with Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs/
 .selenium-cache/
 config.json
 **/__pycache__/
+.omc/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YNU-xk_spider（重构版 v2.0）
 
+[![CI](https://github.com/davidwushi1145/YNU-xk_spider_Refactoring/actions/workflows/ci.yml/badge.svg?branch=new)](https://github.com/davidwushi1145/YNU-xk_spider_Refactoring/actions/workflows/ci.yml)
+
 > [!CAUTION]
 >
 > Disclaimer / 声明
@@ -438,6 +440,33 @@ ruff check src/ --fix
 
 # 运行测试
 pytest
+```
+
+### CI/CD
+
+- `.github/workflows/ci.yml` 会在向 `dev`、`new` 分支 push 或提交 Pull
+  Request 时执行 Ruff、mypy、Python 3.10–3.12 测试矩阵、发行包构建和 wheel
+  安装冒烟测试。
+- `.github/workflows/release.yml` 会在推送 `v*` 标签时重新执行质量检查，验证
+  标签对应的提交已合并到默认分支，并确保标签、`pyproject.toml` 和
+  `ynu_xk_spider.__version__` 三者版本一致，再运行 Python 3.10–3.12 测试矩阵，
+  最后构建 wheel/sdist 并创建 GitHub Release。
+- PyPI 发布默认关闭。若需要启用，请在仓库中创建名为 `pypi` 的
+  [GitHub Environment](https://docs.github.com/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)，
+  在 PyPI 配置对应的
+  [Trusted Publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/)，并将仓库变量
+  `PUBLISH_TO_PYPI` 设置为 `true`。该方式使用 OIDC，不需要保存 PyPI API
+  Token。启用 PyPI 发布前，必须限制 `v*` 标签的创建权限，并为 `pypi`
+  Environment 配置标签保护规则和人工审批。
+- 已发布的 PyPI 版本不可覆盖；若发布阶段失败，应在 GitHub Actions 中使用
+  **Re-run failed jobs** 恢复，而不是覆盖同版本标签或重跑整条发布流程。
+
+发布新版本前，需要同时更新 `pyproject.toml` 与
+`src/ynu_xk_spider/__init__.py` 中的版本号，然后推送匹配的标签：
+
+```bash
+git tag -a v2.1.1 -m "release: v2.1.1"
+git push origin v2.1.1
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@
 
 ## 架构升级
 
-| 特性               | 描述                                                   |
-| ------------------ | ------------------------------------------------------ |
-| **现代项目结构**   | 采用 `/src` 布局，模块职责清晰分离                     |
-| **Pydantic 配置**  | 类型安全的配置验证，支持环境变量覆盖                   |
-| **单例浏览器管理** | `BrowserManager` 线程安全单例，统一 WebDriver 生命周期 |
-| **重试机制**       | 指数退避 + 随机抖动的网络重试装饰器                    |
-| **优雅停机**       | 信号处理 + `threading.Event` 实现无损退出              |
-| **自定义异常**     | 完整的异常层次结构，精准定位问题                       |
-| **完整类型注解**   | 100% Type Hints + Google Style Docstrings              |
+| 特性               | 描述                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| **现代项目结构**   | 采用 `/src` 布局，模块职责清晰分离                           |
+| **Pydantic 配置**  | 类型安全的配置验证，支持环境变量覆盖                         |
+| **类型化领域**     | `CourseType` 枚举统一类别映射（接口路由 / 编码 / 响应解析）  |
+| **浏览器生命周期** | `BrowserManager` 由 Spider 构造持有，登录结束即关闭          |
+| **重试机制**       | 指数退避 + 随机抖动的网络重试装饰器                          |
+| **统一取消语义**   | `StopToken` 贯穿所有等待路径，原生阻塞、即时可中断           |
+| **自定义异常**     | 完整的异常层次结构，精准定位问题                             |
+| **完整类型注解**   | 100% Type Hints + Google Style Docstrings，mypy strict 全绿  |
 
 ---
 
@@ -42,14 +43,15 @@
 
 ---
 
-## 最近更新
+## 最近更新（架构重构 v2.1）
 
-- 修复并发线程数计算：`max_workers` 现在被严格视为上限，不再被课程数强制抬高
-- 优化通知发送：移除 daemon 通知线程，新增等待机制，确保进程收尾阶段尽量完成推送
-- 强化登录页面判定：`_wait_course_page_ready` 不再仅凭 URL 中 `token=` 判定成功
-- 增强 `courseBtn` 容错：按钮瞬时缺失时会告警并重试，避免直接抛错中断
-- 改进调试可观测性：准备点击 `courseBtn` 的最佳努力步骤失败时输出 `DEBUG` 日志
-- 新增监控分组轮询、可中断等待、通知工作线程、模块入口与环境变量加载回归测试（当前测试集共 22 项，均通过）
+- **领域类型化**：课程类别升级为 `CourseType` 枚举，接口路由 / `teachingClassType` 编码 / 响应解析共用一张真值表，未知类别不再被静默回退
+- **统一取消**：新增 `StopToken`（`utils/stop.py`），删除三处 0.1s 切片轮询等待；批次停止改为父子令牌级联
+- **生命周期归属**：`BrowserManager` 去单例，浏览器关闭权收口到 Spider 的 `_perform_login`；登录服务不再隐式关闭浏览器
+- **通知独立**：`Notifier` 协议 + `ServerChanNotifier` + `AsyncNotifier` 移入 `services/notification.py`，选课器只负责选课，通知由 Spider 持有并在批次收尾 flush
+- **HTTP 简化**：`HttpClient.get/post` 合并为单一 `_request` 路径，重试装饰器构造一次复用
+- **更诚实的校验**：`poll_interval_min > max` 直接报配置错误而非静默交换；`main()` 编程调用不再误读进程 argv
+- **清理**：移除全部死代码与 Pydantic v1 兼容垫片；ruff / mypy strict 全绿（当前测试集共 43 项，均通过）
 
 ---
 
@@ -63,19 +65,21 @@ src/ynu_xk_spider/
 ├── exceptions.py          # 自定义异常层次
 ├── logging_config.py      # 日志配置
 ├── utils/
-│   └── retry.py           # 重试装饰器
+│   ├── retry.py           # 重试装饰器
+│   └── stop.py            # StopToken 统一取消原语
 ├── browser/
-│   ├── manager.py         # BrowserManager 单例
+│   ├── manager.py         # BrowserManager（WebDriver 生命周期）
 │   └── captcha.py         # 验证码识别抽象
 ├── http/
 │   ├── client.py          # HTTP 客户端封装
 │   └── endpoints.py       # API 端点构建器
 ├── domain/
-│   ├── models.py          # 领域模型
+│   ├── models.py          # 领域模型（含 CourseType 枚举）
 │   └── services/
 │       ├── login.py       # 登录服务
 │       ├── course_api.py  # 课程 API 客户端
-│       └── course_selector.py  # 选课业务逻辑
+│       ├── course_selector.py  # 选课业务逻辑
+│       └── notification.py     # 通知协议与异步发送
 └── spiders/
     ├── base.py            # BaseSpider 抽象基类
     └── ynu_spider.py      # YNU 选课爬虫实现
@@ -178,7 +182,7 @@ cp config.sample.json config.json
 | `chrome_driver_path` | string | ChromeDriver 路径，留空自动检测        |
 | `headless`           | bool   | 是否无头模式运行浏览器                 |
 | `log_level`          | string | 日志级别：DEBUG/INFO/WARNING/ERROR     |
-| `poll_interval_min`  | float  | 最小轮询间隔（秒）                     |
+| `poll_interval_min`  | float  | 最小轮询间隔（秒），须 ≤ max           |
 | `poll_interval_max`  | float  | 最大轮询间隔（秒）                     |
 | `campus`             | string | 校区代码：`02`=呈贡校区，`01`=东陆校区 |
 | `courses.public`     | array  | 素选课列表                             |
@@ -322,7 +326,7 @@ spider.start()
           LoginSvc["LoginService<br/>(domain/services/login.py)"]
           API["CourseApiClient<br/>(domain/services/course_api.py)"]
           Selector["CourseSelector<br/>(domain/services/course_selector.py)"]
-          Notify["NotificationService<br/>(ServerChan)"]
+          Notify["AsyncNotifier + ServerChan<br/>(services/notification.py)"]
       end
       Selector --> Notify
 
@@ -355,9 +359,16 @@ spider.start()
       API --> SelRes
 
       Selector --> API
-      Selector --> HC
       Selector --> CourseInfo
       Selector --> SelRes
+
+      %% Cancellation
+      Stop["StopToken<br/>(utils/stop.py)"]
+      YCS --> Stop
+      Stop -. "cancel" .-> LoginSvc
+      Stop -. "cancel" .-> Selector
+      Stop -. "cancel" .-> HC
+      YCS -. "flush" .-> Notify
 
       %% Auth flow
       Session -. "token/cookies" .-> HC
@@ -382,12 +393,13 @@ spider.start()
 
 ### 核心设计模式
 
-| 模式           | 应用                                     |
-| -------------- | ---------------------------------------- |
-| **单例模式**   | `BrowserManager` 统一管理 WebDriver 实例 |
-| **模板方法**   | `BaseSpider` 定义生命周期钩子            |
-| **策略模式**   | `CaptchaSolver` 抽象验证码识别实现       |
-| **装饰器模式** | `@retry` 为网络操作添加重试能力          |
+| 模式           | 应用                                             |
+| -------------- | ------------------------------------------------ |
+| **模板方法**   | `BaseSpider` 定义生命周期钩子                    |
+| **策略模式**   | `CaptchaSolver` 抽象验证码识别实现               |
+| **协议接口**   | `Notifier` Protocol 解耦通知实现与选课逻辑       |
+| **装饰器模式** | `@retry` 为网络操作添加重试能力                  |
+| **取消令牌**   | `StopToken` 层级化停止信号，支持批次级联取消     |
 
 ---
 

--- a/src/ynu_xk_spider/app.py
+++ b/src/ynu_xk_spider/app.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import signal
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from types import FrameType
 
@@ -13,9 +15,14 @@ from .exceptions import ConfigError, SpiderError
 from .logging_config import setup_logging
 from .spiders.ynu_spider import YnuCourseSpider
 
+logger = logging.getLogger(__name__)
 
-def parse_args() -> argparse.Namespace:
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments.
+
+    Args:
+        argv: Explicit argument list; defaults to the process argv.
 
     Returns:
         Parsed arguments namespace.
@@ -42,25 +49,24 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Override log level",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main(config_path: Path | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Main application entry point.
 
     Args:
-        config_path: Optional config file path override.
+        argv: Explicit CLI arguments; defaults to the process argv. Pass
+            a list (e.g. []) when calling programmatically to avoid
+            picking up unrelated process arguments.
 
     Returns:
         Exit code (0 for success, 1 for error).
     """
-    args = parse_args()
-
-    if config_path is None:
-        config_path = args.config
+    args = parse_args(argv)
 
     try:
-        settings = AppSettings.load(config_path)
+        settings = AppSettings.load(args.config)
 
         updates = {}
         if args.headless:
@@ -75,10 +81,6 @@ def main(config_path: Path | None = None) -> int:
         return 1
 
     setup_logging(settings)
-
-    import logging
-
-    logger = logging.getLogger(__name__)
 
     logger.info("=" * 60)
     logger.info("YNU Auto Course Selector (Refactored v2.0)")

--- a/src/ynu_xk_spider/app.py
+++ b/src/ynu_xk_spider/app.py
@@ -68,8 +68,7 @@ def main(config_path: Path | None = None) -> int:
         if args.log_level:
             updates["log_level"] = args.log_level
         if updates:
-            copy_method = getattr(settings, "model_copy", None) or settings.copy
-            settings = copy_method(update=updates)
+            settings = settings.model_copy(update=updates)
 
     except ConfigError as exc:
         print(f"Configuration error: {exc}", file=sys.stderr)

--- a/src/ynu_xk_spider/app.py
+++ b/src/ynu_xk_spider/app.py
@@ -88,8 +88,13 @@ def main(config_path: Path | None = None) -> int:
 
     courses = settings.courses.all_courses
     logger.info("Target courses: %d", len(courses))
-    for course, ctype in courses:
-        logger.info("  [%s] %s - %s", ctype, course.name, course.teacher)
+    for target in courses:
+        logger.info(
+            "  [%s] %s - %s",
+            target.course_type.label,
+            target.item.name,
+            target.item.teacher,
+        )
 
     spider = YnuCourseSpider(settings)
 

--- a/src/ynu_xk_spider/browser/manager.py
+++ b/src/ynu_xk_spider/browser/manager.py
@@ -56,7 +56,7 @@ class BrowserManager:
                 if cls._instance is None:
                     cls._instance = cls(settings)
                     logger.debug("BrowserManager singleton created")
-        elif settings is not None and cls._instance._settings != settings:
+        elif cls._instance._settings != settings:
             logger.warning("BrowserManager already initialized with different settings")
         return cls._instance
 

--- a/src/ynu_xk_spider/browser/manager.py
+++ b/src/ynu_xk_spider/browser/manager.py
@@ -37,7 +37,7 @@ class BrowserManager:
         self._settings = settings
         self._driver: WebDriver | None = None
         self._driver_lock = threading.Lock()
-        atexit.register(self.shutdown)
+        self._atexit_registered = False
 
     def get_driver(self) -> WebDriver:
         """Get or create a live WebDriver instance.
@@ -54,7 +54,14 @@ class BrowserManager:
         with self._driver_lock:
             if self._driver is None:
                 self._driver = self._create_driver()
+                self._register_atexit_hook()
         return self._driver
+
+    def _register_atexit_hook(self) -> None:
+        """Register last-resort cleanup while a live driver is owned."""
+        if not self._atexit_registered:
+            atexit.register(self._shutdown_at_exit)
+            self._atexit_registered = True
 
     def _create_driver(self) -> WebDriver:
         """Create a new Chrome WebDriver instance."""
@@ -114,6 +121,14 @@ class BrowserManager:
 
     def shutdown(self) -> None:
         """Quit the WebDriver if present. Safe to call multiple times."""
+        self._shutdown(unregister_atexit=True)
+
+    def _shutdown_at_exit(self) -> None:
+        """Quit the driver during interpreter shutdown."""
+        self._shutdown(unregister_atexit=False)
+
+    def _shutdown(self, *, unregister_atexit: bool) -> None:
+        """Release the driver and optionally remove its exit hook."""
         with self._driver_lock:
             if self._driver is not None:
                 try:
@@ -123,6 +138,9 @@ class BrowserManager:
                     logger.warning("Error during WebDriver shutdown: %s", exc)
                 finally:
                     self._driver = None
+            if unregister_atexit and self._atexit_registered:
+                atexit.unregister(self._shutdown_at_exit)
+                self._atexit_registered = False
 
     def restart(self) -> WebDriver:
         """Shutdown and create a fresh driver instance.

--- a/src/ynu_xk_spider/browser/manager.py
+++ b/src/ynu_xk_spider/browser/manager.py
@@ -1,4 +1,4 @@
-"""Thread-safe singleton WebDriver lifecycle manager."""
+"""Thread-safe WebDriver lifecycle manager."""
 
 from __future__ import annotations
 
@@ -21,52 +21,23 @@ logger = logging.getLogger(__name__)
 
 
 class BrowserManager:
-    """Singleton manager for WebDriver lifecycle.
+    """Manages the WebDriver lifecycle for its owner.
 
-    Thread-safe lazy initialization ensures only one driver instance exists.
-    Automatic cleanup is registered via atexit.
-
-    Attributes:
-        _instance: Singleton instance.
-        _inst_lock: Lock for singleton creation.
+    The spider creates one manager and owns its lifetime: the driver is
+    created lazily, shared while alive, and shut down by the owner (with
+    an atexit hook as a last resort). Shutdown is idempotent.
     """
 
-    _instance: BrowserManager | None = None
-    _inst_lock = threading.Lock()
-
     def __init__(self, settings: AppSettings) -> None:
-        """Initialize manager with settings. Use instance() instead."""
+        """Initialize manager with settings.
+
+        Args:
+            settings: Application settings for driver configuration.
+        """
         self._settings = settings
         self._driver: WebDriver | None = None
         self._driver_lock = threading.Lock()
         atexit.register(self.shutdown)
-
-    @classmethod
-    def instance(cls, settings: AppSettings) -> BrowserManager:
-        """Get or create the singleton instance.
-
-        Args:
-            settings: Application settings for driver configuration.
-
-        Returns:
-            The singleton BrowserManager instance.
-        """
-        if cls._instance is None:
-            with cls._inst_lock:
-                if cls._instance is None:
-                    cls._instance = cls(settings)
-                    logger.debug("BrowserManager singleton created")
-        elif cls._instance._settings != settings:
-            logger.warning("BrowserManager already initialized with different settings")
-        return cls._instance
-
-    @classmethod
-    def reset(cls) -> None:
-        """Reset singleton for testing purposes."""
-        with cls._inst_lock:
-            if cls._instance is not None:
-                cls._instance.shutdown()
-                cls._instance = None
 
     def get_driver(self) -> WebDriver:
         """Get or create a live WebDriver instance.

--- a/src/ynu_xk_spider/config.py
+++ b/src/ynu_xk_spider/config.py
@@ -28,6 +28,8 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+from .domain.models import CourseTarget, CourseType
+
 
 class CourseItem(BaseModel):
     """Single course target configuration."""
@@ -92,20 +94,22 @@ class CoursesConfig(BaseModel):
         return result
 
     @property
-    def all_courses(self) -> list[tuple[CourseItem, str]]:
-        """Return all courses with their category.
+    def all_courses(self) -> list[CourseTarget]:
+        """Return all configured targets with their course category.
 
         Returns:
-            List of tuples (CourseItem, category_label).
+            List of CourseTarget in public, program, pe order.
         """
-        result: list[tuple[CourseItem, str]] = []
-        for course in self.public:
-            result.append((course, "素选"))
-        for course in self.program:
-            result.append((course, "主修"))
-        for course in self.pe:
-            result.append((course, "体育"))
-        return result
+        groups: tuple[tuple[CourseType, list[CourseItem]], ...] = (
+            (CourseType.PUBLIC, self.public),
+            (CourseType.PROGRAM, self.program),
+            (CourseType.PE, self.pe),
+        )
+        return [
+            CourseTarget(item=item, course_type=course_type)
+            for course_type, items in groups
+            for item in items
+        ]
 
 
 class AppSettings(BaseSettings):

--- a/src/ynu_xk_spider/config.py
+++ b/src/ynu_xk_spider/config.py
@@ -269,7 +269,7 @@ class AppSettings(BaseSettings):
                 raise ConfigError(f"Config file not found: {config_file}")
 
             try:
-                return cls()
+                return cls()  # type: ignore[call-arg]
             except ValidationError as e:
                 raise ConfigError(
                     "Config file not found: config.json. Provide the file or set "

--- a/src/ynu_xk_spider/config.py
+++ b/src/ynu_xk_spider/config.py
@@ -230,17 +230,18 @@ class AppSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_poll_interval(self) -> AppSettings:
-        """Ensure min <= max for poll interval.
+        """Reject configurations where the poll interval bounds are inverted.
 
         Returns:
-            Self with normalized poll interval bounds.
+            Self when the poll interval bounds are consistent.
+
+        Raises:
+            ValueError: If poll_interval_min > poll_interval_max.
         """
         if self.poll_interval_min > self.poll_interval_max:
-            return self.model_copy(
-                update={
-                    "poll_interval_min": self.poll_interval_max,
-                    "poll_interval_max": self.poll_interval_min,
-                }
+            raise ValueError(
+                "poll_interval_min must be <= poll_interval_max "
+                f"(got {self.poll_interval_min} > {self.poll_interval_max})"
             )
         return self
 

--- a/src/ynu_xk_spider/domain/models.py
+++ b/src/ynu_xk_spider/domain/models.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import json
 from enum import Enum
+from typing import TYPE_CHECKING, NamedTuple
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from ..config import CourseItem
 
 
 class SessionData(BaseModel):
@@ -29,6 +33,48 @@ class MonitorOutcome(Enum):
     STOPPED = "stopped"
     SESSION_EXPIRED = "session_expired"
     FAILED = "failed"
+
+
+class CourseType(Enum):
+    """Course category with its API mapping attributes.
+
+    Single source of truth for how each category maps onto the selection
+    system API: display label, teachingClassType code, and response shape.
+
+    Attributes:
+        label: Human-readable category name used in logs.
+        class_type_code: teachingClassType value expected by the API.
+        nested_response: Whether the query response nests classes in tcList.
+    """
+
+    PUBLIC = ("素选", "XGXK", False)
+    PROGRAM = ("主修", "FANKC", True)
+    PE = ("体育", "TYKC", True)
+
+    def __init__(
+        self,
+        label: str,
+        class_type_code: str,
+        nested_response: bool,
+    ) -> None:
+        self.label = label
+        self.class_type_code = class_type_code
+        self.nested_response = nested_response
+
+    def __str__(self) -> str:
+        return self.label
+
+
+class CourseTarget(NamedTuple):
+    """A configured course target paired with its category.
+
+    Attributes:
+        item: Course name/teacher pair from configuration.
+        course_type: Category the course belongs to.
+    """
+
+    item: CourseItem
+    course_type: CourseType
 
 
 class CourseInfo(BaseModel):
@@ -70,14 +116,14 @@ class SelectionRequest(BaseModel):
         batch_code: Course selection batch code.
         teaching_class_id: Target class ID.
         class_type: Teaching class type code.
-        campus: Campus code (default "02").
+        campus: Campus code.
     """
 
     student_code: str
     batch_code: str
     teaching_class_id: str
     class_type: str
-    campus: str = "02" # Default campus code, can be modified if needed.
+    campus: str
 
     def to_api_payload(self) -> dict[str, str]:
         """Convert to API request payload format.
@@ -118,7 +164,7 @@ class QueryRequest(BaseModel):
     batch_code: str
     class_type: str
     query_content: str
-    campus: str = "02"
+    campus: str
 
     def to_api_payload(self) -> dict[str, str]:
         """Convert to API request payload format.

--- a/src/ynu_xk_spider/domain/services/course_api.py
+++ b/src/ynu_xk_spider/domain/services/course_api.py
@@ -125,25 +125,6 @@ class CourseApiClient:
 
         return courses
 
-    def find_course_by_teacher(
-        self,
-        courses: list[CourseInfo],
-        teacher_name: str,
-    ) -> CourseInfo | None:
-        """Find a course by teacher name.
-
-        Args:
-            courses: List of courses to search.
-            teacher_name: Teacher name to match.
-
-        Returns:
-            Matching course or None.
-        """
-        for course in courses:
-            if teacher_name in course.teacher_name:
-                return course
-        return None
-
     def find_courses_by_teacher(
         self,
         courses: list[CourseInfo],

--- a/src/ynu_xk_spider/domain/services/course_api.py
+++ b/src/ynu_xk_spider/domain/services/course_api.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Any
 
 from ...exceptions import NetworkError, SessionExpiredError
 from ...http.endpoints import Endpoints
-from ..models import CourseInfo, QueryRequest, SelectionRequest, SelectionResult
+from ..models import (
+    CourseInfo,
+    CourseType,
+    QueryRequest,
+    SelectionRequest,
+    SelectionResult,
+)
 
 if TYPE_CHECKING:
     from ...http.client import HttpClient
@@ -54,13 +60,13 @@ class CourseApiClient:
     def query_courses(
         self,
         course_name: str,
-        course_type: str,
+        course_type: CourseType,
     ) -> list[CourseInfo]:
         """Query available courses by name.
 
         Args:
             course_name: Course name to search.
-            course_type: One of "素选", "主修", "体育".
+            course_type: Course category to query.
 
         Returns:
             List of matching course information.
@@ -72,13 +78,16 @@ class CourseApiClient:
         if not token:
             raise NetworkError("No auth token available")
 
-        url = self._endpoints.get_course_url(course_type, token)
-        class_type = Endpoints.get_class_type(course_type)
+        url = (
+            self._endpoints.public_course(token)
+            if course_type is CourseType.PUBLIC
+            else self._endpoints.program_course(token)
+        )
 
         request = QueryRequest(
             student_code=self._student_code,
             batch_code=self._batch_code,
-            class_type=class_type,
+            class_type=course_type.class_type_code,
             query_content=course_name,
             campus=self._campus,
         )
@@ -92,12 +101,16 @@ class CourseApiClient:
 
         return self._parse_course_list(data, course_type)
 
-    def _parse_course_list(self, data: dict[str, Any], course_type: str) -> list[CourseInfo]:
+    def _parse_course_list(
+        self,
+        data: dict[str, Any],
+        course_type: CourseType,
+    ) -> list[CourseInfo]:
         """Parse course list from API response.
 
         Args:
             data: API response data.
-            course_type: Course type for endpoint detection.
+            course_type: Course category (drives the response shape).
 
         Returns:
             Parsed course information list.
@@ -108,7 +121,7 @@ class CourseApiClient:
         if not data_list:
             return courses
 
-        if course_type in ("主修", "体育"):
+        if course_type.nested_response:
             for category in data_list:
                 tc_list = category.get("tcList", [])
                 for item in tc_list:
@@ -144,13 +157,13 @@ class CourseApiClient:
     def select_course(
         self,
         course: CourseInfo,
-        course_type: str,
+        course_type: CourseType,
     ) -> SelectionResult:
         """Attempt to select a course.
 
         Args:
             course: Target course information.
-            course_type: Course type for API endpoint.
+            course_type: Course category of the target.
 
         Returns:
             Selection result with success status and message.
@@ -165,13 +178,12 @@ class CourseApiClient:
             )
 
         url = self._endpoints.volunteer(token)
-        class_type = Endpoints.get_class_type(course_type)
 
         request = SelectionRequest(
             student_code=self._student_code,
             batch_code=self._batch_code,
             teaching_class_id=course.teaching_class_id,
-            class_type=class_type,
+            class_type=course_type.class_type_code,
             campus=self._campus,
         )
 

--- a/src/ynu_xk_spider/domain/services/course_selector.py
+++ b/src/ynu_xk_spider/domain/services/course_selector.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from ...exceptions import CourseSelectionError, NetworkError, SessionExpiredError
 from ..models import MonitorOutcome
-from .notification import AsyncNotifier, Notifier, ServerChanNotifier
+from .notification import Notifier, ServerChanNotifier
 
 if TYPE_CHECKING:
     from ...config import AppSettings, CourseItem
@@ -49,13 +49,16 @@ class CourseSelector:
         Args:
             api: Course API client.
             settings: Application settings.
-            notifier: Optional notification sink; defaults to async
-                ServerChan push configured from settings.
+            notifier: Optional notification sink; defaults to synchronous
+                ServerChan push configured from settings. Callers that need
+                non-blocking delivery should inject and own an AsyncNotifier.
         """
         self._api = api
         self._settings = settings
-        self._notifier: Notifier = notifier or AsyncNotifier(
-            ServerChanNotifier(settings.server_chan_key)
+        self._notifier: Notifier = (
+            notifier
+            if notifier is not None
+            else ServerChanNotifier(settings.server_chan_key)
         )
         self._hot_path_log_times: dict[str, float] = {}
 

--- a/src/ynu_xk_spider/domain/services/course_selector.py
+++ b/src/ynu_xk_spider/domain/services/course_selector.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 import logging
 import random
-import threading
 import time
 from collections.abc import Callable, Sequence
-from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING
-
-import requests
 
 from ...exceptions import CourseSelectionError, NetworkError, SessionExpiredError
 from ..models import MonitorOutcome
+from .notification import AsyncNotifier, Notifier, ServerChanNotifier
 
 if TYPE_CHECKING:
     from ...config import AppSettings, CourseItem
@@ -22,40 +19,6 @@ if TYPE_CHECKING:
     from .course_api import CourseApiClient
 
 logger = logging.getLogger(__name__)
-
-
-class NotificationService:
-    """Simple notification service via ServerChan."""
-
-    def __init__(self, server_key: str | None = None) -> None:
-        """Initialize notification service.
-
-        Args:
-            server_key: ServerChan API key.
-        """
-        self._server_key = server_key
-
-    def send(self, title: str, content: str) -> None:
-        """Send notification via WeChat.
-
-        Args:
-            title: Notification title.
-            content: Notification body.
-        """
-        if not self._server_key:
-            return
-
-        try:
-            url = f"https://sctapi.ftqq.com/{self._server_key}.send"
-            requests.post(url, data={"text": title, "desp": content}, timeout=5)
-            logger.debug("Notification sent: %s", title)
-        except Exception as exc:
-            logger.warning("Notification failed: %s", exc)
-
-    @property
-    def enabled(self) -> bool:
-        """Whether notification sending is configured."""
-        return bool(self._server_key)
 
 
 class CourseSelector:
@@ -79,52 +42,22 @@ class CourseSelector:
         self,
         api: CourseApiClient,
         settings: AppSettings,
-        notifier: NotificationService | None = None,
+        notifier: Notifier | None = None,
     ) -> None:
         """Initialize course selector.
 
         Args:
             api: Course API client.
             settings: Application settings.
-            notifier: Optional notification service.
+            notifier: Optional notification sink; defaults to async
+                ServerChan push configured from settings.
         """
         self._api = api
         self._settings = settings
-        self._notifier = notifier or NotificationService(settings.server_chan_key)
-        self._notification_executor: ThreadPoolExecutor | None = None
-        self._notification_futures: list[Future[None]] = []
-        self._notification_lock = threading.Lock()
+        self._notifier: Notifier = notifier or AsyncNotifier(
+            ServerChanNotifier(settings.server_chan_key)
+        )
         self._hot_path_log_times: dict[str, float] = {}
-
-    def _notify_async(self, title: str, content: str) -> None:
-        """Send notifications off the critical selection path."""
-        if not self._notifier.enabled:
-            return
-        with self._notification_lock:
-            self._notification_futures = [
-                future for future in self._notification_futures if not future.done()
-            ]
-            if self._notification_executor is None:
-                self._notification_executor = ThreadPoolExecutor(
-                    max_workers=1,
-                    thread_name_prefix="notification-sender",
-                )
-            future = self._notification_executor.submit(self._notifier.send, title, content)
-            self._notification_futures.append(future)
-
-    def wait_for_notifications(self, timeout: float | None = None) -> None:
-        """Wait for pending async notifications to finish sending."""
-        with self._notification_lock:
-            futures = list(self._notification_futures)
-            executor = self._notification_executor
-            self._notification_futures.clear()
-            self._notification_executor = None
-
-        if futures:
-            wait(futures, timeout=timeout)
-
-        if executor is not None:
-            executor.shutdown(wait=timeout is None)
 
     def run_monitoring_loop(
         self,
@@ -307,14 +240,14 @@ class CourseSelector:
         for slot in available_slots:
             msg = f"Found spot! {course.name}-{course.teacher} remaining: {slot.remaining}"
             logger.info(msg)
-            self._notify_async("Course Alert", msg)
+            self._notifier.send("Course Alert", msg)
 
             result = self._api.select_course(slot, course_type)
 
             if result.success:
                 success_msg = f"Selection successful: {course.name}"
                 logger.info(success_msg)
-                self._notify_async("Selection Success", success_msg)
+                self._notifier.send("Selection Success", success_msg)
                 return True
 
             if "时间冲突" in result.message or "该课程与已选课程时间冲突" in result.message:

--- a/src/ynu_xk_spider/domain/services/course_selector.py
+++ b/src/ynu_xk_spider/domain/services/course_selector.py
@@ -17,7 +17,7 @@ from ..models import MonitorOutcome
 
 if TYPE_CHECKING:
     from ...config import AppSettings, CourseItem
-    from ..models import CourseInfo
+    from ..models import CourseInfo, CourseType
     from .course_api import CourseApiClient
 
 logger = logging.getLogger(__name__)
@@ -128,14 +128,14 @@ class CourseSelector:
     def run_monitoring_loop(
         self,
         course: CourseItem,
-        course_type: str,
+        course_type: CourseType,
         is_stopped: Callable[[], bool],
     ) -> MonitorOutcome:
         """Monitor a single course and attempt selection when available.
 
         Args:
             course: Target course configuration.
-            course_type: One of "素选", "主修", "体育".
+            course_type: Course category of the target.
             is_stopped: Callable returning True when stop requested.
 
         Returns:
@@ -151,7 +151,7 @@ class CourseSelector:
     def run_group_monitoring_loop(
         self,
         course_name: str,
-        course_type: str,
+        course_type: CourseType,
         targets: Sequence[CourseItem],
         is_stopped: Callable[[], bool],
     ) -> MonitorOutcome:
@@ -292,7 +292,7 @@ class CourseSelector:
     def _try_select_available_slots(
         self,
         course: CourseItem,
-        course_type: str,
+        course_type: CourseType,
         available_slots: Sequence[CourseInfo],
     ) -> bool:
         """Try selecting the target from available slots."""

--- a/src/ynu_xk_spider/domain/services/course_selector.py
+++ b/src/ynu_xk_spider/domain/services/course_selector.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from ...exceptions import CourseSelectionError, NetworkError, SessionExpiredError
 from ..models import MonitorOutcome

--- a/src/ynu_xk_spider/domain/services/course_selector.py
+++ b/src/ynu_xk_spider/domain/services/course_selector.py
@@ -17,6 +17,7 @@ from ..models import MonitorOutcome
 
 if TYPE_CHECKING:
     from ...config import AppSettings, CourseItem
+    from ...utils.stop import StopToken
     from ..models import CourseInfo, CourseType
     from .course_api import CourseApiClient
 
@@ -129,14 +130,14 @@ class CourseSelector:
         self,
         course: CourseItem,
         course_type: CourseType,
-        is_stopped: Callable[[], bool],
+        stop: StopToken,
     ) -> MonitorOutcome:
         """Monitor a single course and attempt selection when available.
 
         Args:
             course: Target course configuration.
             course_type: Course category of the target.
-            is_stopped: Callable returning True when stop requested.
+            stop: Stop token honored during monitoring.
 
         Returns:
             Monitoring outcome for this single target.
@@ -145,7 +146,7 @@ class CourseSelector:
             course_name=course.name,
             course_type=course_type,
             targets=[course],
-            is_stopped=is_stopped,
+            stop=stop,
         )
 
     def run_group_monitoring_loop(
@@ -153,7 +154,7 @@ class CourseSelector:
         course_name: str,
         course_type: CourseType,
         targets: Sequence[CourseItem],
-        is_stopped: Callable[[], bool],
+        stop: StopToken,
     ) -> MonitorOutcome:
         """Monitor a course group with one shared query per polling cycle."""
         pending_targets = list(targets)
@@ -170,7 +171,7 @@ class CourseSelector:
         fail_count = 0
         max_consecutive_failures = 5
 
-        while pending_targets and not is_stopped():
+        while pending_targets and not stop.is_set():
             try:
                 courses = self._api.query_courses(course_name, course_type)
 
@@ -180,14 +181,14 @@ class CourseSelector:
                         "[%s] No courses found",
                         course_name,
                     )
-                    if not self._wait_random(is_stopped):
+                    if not self._wait_random(stop):
                         return MonitorOutcome.STOPPED
                     continue
 
                 remaining_targets: list[CourseItem] = []
                 for index, target in enumerate(pending_targets):
                     try:
-                        if is_stopped():
+                        if stop.is_set():
                             return MonitorOutcome.STOPPED
 
                         teacher_slots = self._api.find_courses_by_teacher(
@@ -226,7 +227,7 @@ class CourseSelector:
                     return MonitorOutcome.SUCCESS
 
                 pending_targets = remaining_targets
-                if not self._wait_random(is_stopped):
+                if not self._wait_random(stop):
                     return MonitorOutcome.STOPPED
                 fail_count = 0
 
@@ -240,7 +241,7 @@ class CourseSelector:
                     exc=exc,
                     fail_count=fail_count,
                     max_consecutive_failures=max_consecutive_failures,
-                    is_stopped=is_stopped,
+                    stop=stop,
                     log_method=logger.warning,
                     log_message="[%s] Error: %s (fail %d)",
                 )
@@ -253,14 +254,14 @@ class CourseSelector:
                     exc=exc,
                     fail_count=fail_count,
                     max_consecutive_failures=max_consecutive_failures,
-                    is_stopped=is_stopped,
+                    stop=stop,
                     log_method=logger.error,
                     log_message="[%s] Unexpected error: %s (fail %d)",
                 )
                 if outcome is not None:
                     return outcome
 
-        return MonitorOutcome.STOPPED if is_stopped() else MonitorOutcome.FAILED
+        return MonitorOutcome.STOPPED if stop.is_set() else MonitorOutcome.FAILED
 
     def _handle_monitoring_failure(
         self,
@@ -268,13 +269,13 @@ class CourseSelector:
         exc: Exception,
         fail_count: int,
         max_consecutive_failures: int,
-        is_stopped: Callable[[], bool],
+        stop: StopToken,
         *,
         log_method: Callable[..., None],
         log_message: str,
     ) -> tuple[int, MonitorOutcome | None]:
         """Handle a failed monitoring attempt and decide whether to retry."""
-        if is_stopped():
+        if stop.is_set():
             return fail_count, MonitorOutcome.STOPPED
 
         fail_count += 1
@@ -284,7 +285,7 @@ class CourseSelector:
             logger.error("[%s] Too many failures, stopping", course_name)
             return fail_count, MonitorOutcome.FAILED
 
-        if not self._wait_with_stop(5, is_stopped):
+        if not self._wait_with_stop(5, stop):
             return fail_count, MonitorOutcome.STOPPED
 
         return fail_count, None
@@ -357,24 +358,18 @@ class CourseSelector:
         self._hot_path_log_times[key] = now
         logger.debug(message, *args)
 
-    def _wait_random(self, is_stopped: Callable[[], bool]) -> bool:
+    def _wait_random(self, stop: StopToken) -> bool:
         """Wait for a random interval within configured bounds."""
         interval = random.uniform(
             self._settings.poll_interval_min,
             self._settings.poll_interval_max,
         )
-        return self._wait_with_stop(interval, is_stopped)
+        return self._wait_with_stop(interval, stop)
 
-    def _wait_with_stop(
-        self,
-        delay: float,
-        is_stopped: Callable[[], bool],
-    ) -> bool:
-        """Sleep in short slices so stop requests can interrupt polling."""
-        deadline = time.monotonic() + delay
-        while not is_stopped():
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return True
-            time.sleep(min(0.1, remaining))
-        return False
+    def _wait_with_stop(self, delay: float, stop: StopToken) -> bool:
+        """Block for a delay unless stop is requested first.
+
+        Returns:
+            True if the full delay elapsed, False when interrupted by stop.
+        """
+        return stop.wait(delay)

--- a/src/ynu_xk_spider/domain/services/login.py
+++ b/src/ynu_xk_spider/domain/services/login.py
@@ -18,6 +18,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 from ...exceptions import CaptchaError, LoginError, StopRequestedError
+from ...utils.stop import StopToken
 from ..models import SessionData
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ class LoginService:
         settings: AppSettings,
         browser: BrowserManager,
         solver: CaptchaSolver,
-        is_stopped: Callable[[], bool] | None = None,
+        stop: StopToken | None = None,
     ) -> None:
         """Initialize login service.
 
@@ -62,12 +63,12 @@ class LoginService:
             settings: Application settings.
             browser: Browser manager for WebDriver access.
             solver: Captcha solver instance.
-            is_stopped: Optional callback indicating whether shutdown was requested.
+            stop: Optional stop token signaling shutdown requests.
         """
         self._settings = settings
         self._browser = browser
         self._solver = solver
-        self._is_stopped = is_stopped or (lambda: False)
+        self._stop = stop or StopToken()
 
     def login(self) -> SessionData:
         """Perform login and return session data.
@@ -512,7 +513,7 @@ class LoginService:
         """Wait for a Selenium condition while allowing stop interruption."""
         deadline = time.monotonic() + timeout
         while True:
-            self._ensure_not_stopped()
+            self._stop.raise_if_set()
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutException()
@@ -522,18 +523,12 @@ class LoginService:
                 continue
 
     def _wait_or_stop(self, delay: float) -> None:
-        """Sleep in short slices and abort when stop is requested."""
-        deadline = time.monotonic() + delay
-        while True:
-            self._ensure_not_stopped()
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            time.sleep(min(0.1, remaining))
+        """Block for a delay, aborting when stop is requested.
 
-    def _ensure_not_stopped(self) -> None:
-        """Raise when a stop request has been observed."""
-        if self._is_stopped():
+        Raises:
+            StopRequestedError: If stop is requested before the delay elapses.
+        """
+        if not self._stop.wait(delay):
             raise StopRequestedError("Stop requested")
 
     def _extract_session_data(self, driver: WebDriver) -> SessionData:

--- a/src/ynu_xk_spider/domain/services/login.py
+++ b/src/ynu_xk_spider/domain/services/login.py
@@ -572,8 +572,4 @@ class LoginService:
 
         logger.info("Session extracted: token=%s..., batch=%s", token[:8], batch_code)
 
-        # Close browser after successful login (HTTP client takes over)
-        self._browser.shutdown()
-        logger.info("Browser closed after successful login")
-
         return SessionData(cookies=cookies, token=token, batch_code=batch_code)

--- a/src/ynu_xk_spider/domain/services/notification.py
+++ b/src/ynu_xk_spider/domain/services/notification.py
@@ -1,0 +1,121 @@
+"""Notification services for selection results."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from typing import Protocol
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class Notifier(Protocol):
+    """Anything that can push a notification to the user."""
+
+    @property
+    def enabled(self) -> bool:
+        """Whether sending is configured."""
+        ...
+
+    def send(self, title: str, content: str) -> None:
+        """Send a notification."""
+        ...
+
+
+class ServerChanNotifier:
+    """Synchronous WeChat push via ServerChan."""
+
+    def __init__(self, server_key: str | None = None) -> None:
+        """Initialize notifier.
+
+        Args:
+            server_key: ServerChan API key; empty or None disables sending.
+        """
+        self._server_key = server_key
+
+    @property
+    def enabled(self) -> bool:
+        """Whether notification sending is configured."""
+        return bool(self._server_key)
+
+    def send(self, title: str, content: str) -> None:
+        """Send notification via WeChat.
+
+        Args:
+            title: Notification title.
+            content: Notification body.
+        """
+        if not self._server_key:
+            return
+
+        try:
+            url = f"https://sctapi.ftqq.com/{self._server_key}.send"
+            requests.post(url, data={"text": title, "desp": content}, timeout=5)
+            logger.debug("Notification sent: %s", title)
+        except Exception as exc:
+            logger.warning("Notification failed: %s", exc)
+
+
+class AsyncNotifier:
+    """Wraps a notifier so sends happen off the caller's thread.
+
+    Sends are dispatched on a single background worker so the selection
+    hot path never blocks on network I/O. flush() waits for pending
+    sends and releases the worker; the wrapper is reusable afterwards
+    (the worker is recreated on the next send).
+    """
+
+    def __init__(self, inner: Notifier) -> None:
+        """Initialize wrapper.
+
+        Args:
+            inner: Notifier performing the actual (blocking) send.
+        """
+        self._inner = inner
+        self._executor: ThreadPoolExecutor | None = None
+        self._futures: list[Future[None]] = []
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the wrapped notifier is configured."""
+        return self._inner.enabled
+
+    def send(self, title: str, content: str) -> None:
+        """Queue a notification without blocking the caller.
+
+        Args:
+            title: Notification title.
+            content: Notification body.
+        """
+        if not self._inner.enabled:
+            return
+        with self._lock:
+            self._futures = [f for f in self._futures if not f.done()]
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="notification-sender",
+                )
+            self._futures.append(self._executor.submit(self._inner.send, title, content))
+
+    def flush(self, timeout: float | None = None) -> None:
+        """Wait for pending sends to finish and release the worker.
+
+        Args:
+            timeout: Optional maximum seconds to wait; None waits until done.
+        """
+        with self._lock:
+            futures = list(self._futures)
+            executor = self._executor
+            self._futures.clear()
+            self._executor = None
+
+        if futures:
+            wait(futures, timeout=timeout)
+
+        if executor is not None:
+            executor.shutdown(wait=timeout is None)

--- a/src/ynu_xk_spider/http/client.py
+++ b/src/ynu_xk_spider/http/client.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from ..exceptions import NetworkError, SessionExpiredError
 from ..utils.retry import retry
@@ -163,7 +163,9 @@ class HttpClient:
             return True
         return not self._stop_event.wait(delay)
 
-    def _create_retry_decorator(self) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
+    def _create_retry_decorator(
+        self,
+    ) -> Callable[[Callable[[], requests.Response]], Callable[[], requests.Response]]:
         """Create retry decorator with current settings."""
         return retry(
             exceptions=(requests.RequestException, NetworkError),

--- a/src/ynu_xk_spider/http/client.py
+++ b/src/ynu_xk_spider/http/client.py
@@ -73,6 +73,7 @@ class HttpClient:
         self._cookies: dict[str, str] = {}
         self._auth_generation = 0
         self._base_headers = self._build_base_headers()
+        self._retry = self._create_retry_decorator()
 
     def _build_base_headers(self) -> dict[str, str]:
         """Build default headers shared by all per-thread sessions."""
@@ -178,12 +179,13 @@ class HttpClient:
             sleep=self._sleep_for_retry,
         )
 
-    def get(self, url: str, **kwargs: Any) -> requests.Response:
-        """Send GET request with retry.
+    def _request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Send an HTTP request with retry and session-expiry detection.
 
         Args:
+            method: HTTP method name (e.g. "GET", "POST").
             url: Target URL.
-            **kwargs: Additional arguments for requests.get.
+            **kwargs: Additional arguments for requests.Session.request.
 
         Returns:
             Response object.
@@ -194,17 +196,33 @@ class HttpClient:
         """
         kwargs.setdefault("timeout", self._timeout)
 
-        @self._create_retry_decorator()
-        def _get() -> requests.Response:
+        @self._retry
+        def _do() -> requests.Response:
             try:
                 session = self._get_session()
-                resp = session.get(url, **kwargs)
+                resp = session.request(method, url, **kwargs)
                 self._check_session_expired(resp)
                 return resp
             except requests.RequestException as exc:
                 raise NetworkError(str(exc)) from exc
 
-        return _get()
+        return _do()
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        """Send GET request with retry.
+
+        Args:
+            url: Target URL.
+            **kwargs: Additional arguments for the underlying request.
+
+        Returns:
+            Response object.
+
+        Raises:
+            NetworkError: On request failure.
+            SessionExpiredError: If session is expired.
+        """
+        return self._request("GET", url, **kwargs)
 
     def post(
         self,
@@ -219,7 +237,7 @@ class HttpClient:
             url: Target URL.
             data: Form data.
             json: JSON payload.
-            **kwargs: Additional arguments for requests.post.
+            **kwargs: Additional arguments for the underlying request.
 
         Returns:
             Response object.
@@ -228,19 +246,7 @@ class HttpClient:
             NetworkError: On request failure.
             SessionExpiredError: If session is expired.
         """
-        kwargs.setdefault("timeout", self._timeout)
-
-        @self._create_retry_decorator()
-        def _post() -> requests.Response:
-            try:
-                session = self._get_session()
-                resp = session.post(url, data=data, json=json, **kwargs)
-                self._check_session_expired(resp)
-                return resp
-            except requests.RequestException as exc:
-                raise NetworkError(str(exc)) from exc
-
-        return _post()
+        return self._request("POST", url, data=data, json=json, **kwargs)
 
     def _check_session_expired(self, resp: requests.Response) -> None:
         """Check if response indicates session expiration.

--- a/src/ynu_xk_spider/http/client.py
+++ b/src/ynu_xk_spider/http/client.py
@@ -16,6 +16,7 @@ from ..utils.retry import retry
 
 if TYPE_CHECKING:
     from ..config import AppSettings
+    from ..utils.stop import StopToken
 
 logger = logging.getLogger(__name__)
 
@@ -53,17 +54,17 @@ class HttpClient:
     def __init__(
         self,
         settings: AppSettings,
-        stop_event: threading.Event | None = None,
+        stop: StopToken | None = None,
     ) -> None:
         """Initialize HTTP client.
 
         Args:
             settings: Application settings.
-            stop_event: Optional stop event used to interrupt retry backoff.
+            stop: Optional stop token used to interrupt retry backoff.
         """
         self._settings = settings
         self._timeout = settings.http_timeout
-        self._stop_event = stop_event
+        self._stop = stop
         self._thread_local = threading.local()
         self._sessions: list[requests.Session] = []
         self._sessions_lock = threading.Lock()
@@ -158,10 +159,10 @@ class HttpClient:
 
     def _sleep_for_retry(self, delay: float) -> bool:
         """Sleep between retries, aborting early when stop is requested."""
-        if self._stop_event is None:
+        if self._stop is None:
             time.sleep(delay)
             return True
-        return not self._stop_event.wait(delay)
+        return self._stop.wait(delay)
 
     def _create_retry_decorator(
         self,

--- a/src/ynu_xk_spider/http/endpoints.py
+++ b/src/ynu_xk_spider/http/endpoints.py
@@ -71,34 +71,3 @@ class Endpoints:
 
         timestamp = int(time.time() * 1000)
         return f"{self._base}/xsxkapp/sys/xsxkapp/elective/courseResult.do?timestamp={timestamp}&studentCode={student_code}&electiveBatchCode={batch_code}"
-
-    def get_course_url(self, course_type: str, token: str) -> str:
-        """Get appropriate course query URL based on type.
-
-        Args:
-            course_type: One of "素选", "主修", "体育".
-            token: Authentication token.
-
-        Returns:
-            Appropriate API URL.
-        """
-        if course_type == "素选":
-            return self.public_course(token)
-        return self.program_course(token)
-
-    @staticmethod
-    def get_class_type(course_type: str) -> str:
-        """Get teachingClassType value for API.
-
-        Args:
-            course_type: One of "素选", "主修", "体育".
-
-        Returns:
-            API class type code.
-        """
-        mapping = {
-            "素选": "XGXK",
-            "主修": "FANKC",
-            "体育": "TYKC",
-        }
-        return mapping.get(course_type, "XGXK")

--- a/src/ynu_xk_spider/spiders/base.py
+++ b/src/ynu_xk_spider/spiders/base.py
@@ -28,7 +28,6 @@ class BaseSpider(ABC):
         """Start the spider run loop with lifecycle hooks."""
         logger.info("Spider starting")
         try:
-            self.on_start()
             self.run_loop()
         except Exception as exc:
             logger.error("Spider error: %s", exc)
@@ -50,21 +49,9 @@ class BaseSpider(ABC):
         """
         return self.stop_event.is_set()
 
-    def raise_if_stopped(self) -> None:
-        """Raise RuntimeError if stop was requested.
-
-        Raises:
-            RuntimeError: If stop_event is set.
-        """
-        if self.is_stopped():
-            raise RuntimeError("Stop requested")
-
     @abstractmethod
     def run_loop(self) -> None:
         """Main execution loop. Must honor self.stop_event."""
 
-    def on_start(self) -> None:
-        """Hook called before run_loop. Override for setup."""
-
-    def on_stop(self) -> None:
+    def on_stop(self) -> None:  # noqa: B027 - optional hook, intentionally empty
         """Hook called after run_loop. Override for cleanup."""

--- a/src/ynu_xk_spider/spiders/base.py
+++ b/src/ynu_xk_spider/spiders/base.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-import threading
 from abc import ABC, abstractmethod
 from typing import Final
+
+from ..utils.stop import StopToken
 
 logger = logging.getLogger(__name__)
 
@@ -13,16 +14,16 @@ logger = logging.getLogger(__name__)
 class BaseSpider(ABC):
     """Abstract base spider providing lifecycle and stop signal handling.
 
-    Subclasses implement run_loop() and use self.stop_event to detect
+    Subclasses implement run_loop() and use self.stop_token to detect
     shutdown requests. The start() method handles the full lifecycle.
 
     Attributes:
-        stop_event: Threading event for graceful shutdown signaling.
+        stop_token: Cancellation token for graceful shutdown signaling.
     """
 
     def __init__(self) -> None:
-        """Initialize spider with stop event."""
-        self.stop_event: Final[threading.Event] = threading.Event()
+        """Initialize spider with stop token."""
+        self.stop_token: Final[StopToken] = StopToken()
 
     def start(self) -> None:
         """Start the spider run loop with lifecycle hooks."""
@@ -39,7 +40,7 @@ class BaseSpider(ABC):
     def stop(self) -> None:
         """Signal the spider to stop gracefully."""
         logger.info("Stop signal received")
-        self.stop_event.set()
+        self.stop_token.set()
 
     def is_stopped(self) -> bool:
         """Check if stop has been requested.
@@ -47,11 +48,11 @@ class BaseSpider(ABC):
         Returns:
             True if stop was signaled.
         """
-        return self.stop_event.is_set()
+        return self.stop_token.is_set()
 
     @abstractmethod
     def run_loop(self) -> None:
-        """Main execution loop. Must honor self.stop_event."""
+        """Main execution loop. Must honor self.stop_token."""
 
     def on_stop(self) -> None:  # noqa: B027 - optional hook, intentionally empty
         """Hook called after run_loop. Override for cleanup."""

--- a/src/ynu_xk_spider/spiders/ynu_spider.py
+++ b/src/ynu_xk_spider/spiders/ynu_spider.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
 
@@ -52,7 +51,7 @@ class YnuCourseSpider(BaseSpider):
         super().__init__()
         self._settings = settings
         self._browser = BrowserManager.instance(settings)
-        self._http = HttpClient(settings, stop_event=self.stop_event)
+        self._http = HttpClient(settings, stop=self.stop_token)
         self._solver = DdddocrSolver()
         self._max_workers = max_workers
 
@@ -119,7 +118,7 @@ class YnuCourseSpider(BaseSpider):
 
     def _wait_or_stop(self, delay: float) -> bool:
         """Wait for a delay unless a stop request arrives first."""
-        return not self.stop_event.wait(delay)
+        return self.stop_token.wait(delay)
 
     def _perform_login(self) -> SessionData:
         """Perform login and return session data.
@@ -131,7 +130,7 @@ class YnuCourseSpider(BaseSpider):
             self._settings,
             self._browser,
             self._solver,
-            is_stopped=self.is_stopped,
+            stop=self.stop_token,
         )
 
         try:
@@ -170,13 +169,10 @@ class YnuCourseSpider(BaseSpider):
         grouped_courses = self._group_course_targets(courses)
         futures: list[Future[MonitorOutcome]] = []
         future_targets: dict[Future[MonitorOutcome], list[CourseItem]] = {}
-        batch_stop_event = threading.Event()
+        batch_stop = self.stop_token.child()
         success_count = 0
         total_targets = len(courses)
         worker_count = self._resolve_worker_count(len(grouped_courses))
-
-        def should_stop() -> bool:
-            return self.is_stopped() or batch_stop_event.is_set()
 
         try:
             with ThreadPoolExecutor(max_workers=worker_count) as executor:
@@ -186,7 +182,7 @@ class YnuCourseSpider(BaseSpider):
                         course_name,
                         course_type,
                         targets,
-                        should_stop,
+                        batch_stop,
                     )
                     futures.append(future)
                     future_targets[future] = targets
@@ -206,14 +202,14 @@ class YnuCourseSpider(BaseSpider):
                                 logger.info("Monitoring stopped")
                                 return MonitorOutcome.STOPPED
                             logger.warning("Monitoring group stopped unexpectedly")
-                            batch_stop_event.set()
+                            batch_stop.set()
                             return MonitorOutcome.FAILED
                         if result in (
                             MonitorOutcome.SESSION_EXPIRED,
                             MonitorOutcome.FAILED,
                         ):
                             logger.info("Monitoring group ended with %s", result.value)
-                            batch_stop_event.set()
+                            batch_stop.set()
                             return result
                         if result is MonitorOutcome.SUCCESS:
                             success_count += len(future_targets[future])
@@ -237,7 +233,7 @@ class YnuCourseSpider(BaseSpider):
                                 )
                     except Exception as exc:
                         logger.error("Thread error: %s", exc)
-                        batch_stop_event.set()
+                        batch_stop.set()
                         return MonitorOutcome.FAILED
 
             return MonitorOutcome.SUCCESS

--- a/src/ynu_xk_spider/spiders/ynu_spider.py
+++ b/src/ynu_xk_spider/spiders/ynu_spider.py
@@ -12,6 +12,7 @@ from ..domain.models import MonitorOutcome
 from ..domain.services.course_api import CourseApiClient
 from ..domain.services.course_selector import CourseSelector
 from ..domain.services.login import LoginService
+from ..domain.services.notification import AsyncNotifier, ServerChanNotifier
 from ..exceptions import LoginError, StopRequestedError
 from ..http.client import HttpClient
 from .base import BaseSpider
@@ -53,6 +54,7 @@ class YnuCourseSpider(BaseSpider):
         self._browser = BrowserManager(settings)
         self._http = HttpClient(settings, stop=self.stop_token)
         self._solver = DdddocrSolver()
+        self._notifier = AsyncNotifier(ServerChanNotifier(settings.server_chan_key))
         self._max_workers = max_workers
 
     def run_loop(self) -> None:
@@ -75,7 +77,7 @@ class YnuCourseSpider(BaseSpider):
                     campus=self._settings.campus,
                 )
 
-                selector = CourseSelector(api, self._settings)
+                selector = CourseSelector(api, self._settings, notifier=self._notifier)
 
                 monitoring_result = self._run_monitoring(selector)
                 if monitoring_result is MonitorOutcome.STOPPED:
@@ -241,7 +243,7 @@ class YnuCourseSpider(BaseSpider):
 
             return MonitorOutcome.SUCCESS
         finally:
-            selector.wait_for_notifications()
+            self._notifier.flush()
 
     def on_stop(self) -> None:
         """Cleanup on spider stop."""

--- a/src/ynu_xk_spider/spiders/ynu_spider.py
+++ b/src/ynu_xk_spider/spiders/ynu_spider.py
@@ -50,7 +50,7 @@ class YnuCourseSpider(BaseSpider):
         """
         super().__init__()
         self._settings = settings
-        self._browser = BrowserManager.instance(settings)
+        self._browser = BrowserManager(settings)
         self._http = HttpClient(settings, stop=self.stop_token)
         self._solver = DdddocrSolver()
         self._max_workers = max_workers
@@ -98,7 +98,6 @@ class YnuCourseSpider(BaseSpider):
                     self.MAX_CONSECUTIVE_LOGIN_FAILURES,
                     exc,
                 )
-                self._browser.shutdown()
                 if login_failures >= self.MAX_CONSECUTIVE_LOGIN_FAILURES:
                     logger.error("Too many consecutive login failures, stopping spider")
                     self.stop()
@@ -108,7 +107,6 @@ class YnuCourseSpider(BaseSpider):
 
             except Exception as exc:
                 logger.error("Unexpected error: %s", exc)
-                self._browser.shutdown()
                 if not self._wait_or_stop(5):
                     break
 
@@ -122,6 +120,9 @@ class YnuCourseSpider(BaseSpider):
 
     def _perform_login(self) -> SessionData:
         """Perform login and return session data.
+
+        The browser is only needed while logging in; it is closed on every
+        exit path once the attempt finishes (the HTTP client takes over).
 
         Returns:
             SessionData if login succeeds.
@@ -142,6 +143,8 @@ class YnuCourseSpider(BaseSpider):
         except Exception as exc:
             logger.error("Login failed: %s", exc)
             raise LoginError(f"Login failed: {exc}") from exc
+        finally:
+            self._browser.shutdown()
 
     def _resolve_worker_count(self, total_courses: int) -> int:
         """Compute worker count for the thread pool."""

--- a/src/ynu_xk_spider/spiders/ynu_spider.py
+++ b/src/ynu_xk_spider/spiders/ynu_spider.py
@@ -19,7 +19,7 @@ from .base import BaseSpider
 
 if TYPE_CHECKING:
     from ..config import AppSettings, CourseItem
-    from ..domain.models import SessionData
+    from ..domain.models import CourseTarget, CourseType, SessionData
 
 logger = logging.getLogger(__name__)
 
@@ -251,13 +251,13 @@ class YnuCourseSpider(BaseSpider):
 
     def _group_course_targets(
         self,
-        courses: list[tuple[CourseItem, str]],
-    ) -> list[tuple[str, str, list[CourseItem]]]:
+        courses: list[CourseTarget],
+    ) -> list[tuple[str, CourseType, list[CourseItem]]]:
         """Group targets by (course type, course name) to avoid duplicate queries."""
-        grouped: dict[tuple[str, str], list[CourseItem]] = {}
-        for course, course_type in courses:
-            key = (course_type, course.name)
-            grouped.setdefault(key, []).append(course)
+        grouped: dict[tuple[CourseType, str], list[CourseItem]] = {}
+        for target in courses:
+            key = (target.course_type, target.item.name)
+            grouped.setdefault(key, []).append(target.item)
 
         return [
             (course_name, course_type, targets)

--- a/src/ynu_xk_spider/utils/stop.py
+++ b/src/ynu_xk_spider/utils/stop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import weakref
 
 from ..exceptions import StopRequestedError
 
@@ -19,7 +20,8 @@ class StopToken:
 
     def __init__(self) -> None:
         self._event = threading.Event()
-        self._children: list[StopToken] = []
+        self._children: weakref.WeakSet[StopToken] = weakref.WeakSet()
+        self._parent: StopToken | None = None
         self._lock = threading.Lock()
 
     def set(self) -> None:
@@ -29,6 +31,7 @@ class StopToken:
             children = list(self._children)
         for child in children:
             child.set()
+        self._parent = None
 
     def is_set(self) -> bool:
         """Return True if stop has been requested."""
@@ -57,9 +60,10 @@ class StopToken:
     def child(self) -> StopToken:
         """Create a linked token that also stops when this one does."""
         token = StopToken()
+        # Keep the propagation chain alive while any descendant remains active.
+        token._parent = self
         with self._lock:
-            self._children = [c for c in self._children if not c.is_set()]
-            self._children.append(token)
+            self._children.add(token)
         if self._event.is_set():
             token.set()
         return token

--- a/src/ynu_xk_spider/utils/stop.py
+++ b/src/ynu_xk_spider/utils/stop.py
@@ -1,0 +1,65 @@
+"""Unified cancellation primitive shared across the application."""
+
+from __future__ import annotations
+
+import threading
+
+from ..exceptions import StopRequestedError
+
+
+class StopToken:
+    """Cooperative stop signal wrapping a threading.Event.
+
+    A single token is owned by the spider and handed to every component
+    that sleeps or loops, so waiting is native blocking (no polling
+    slices) and stop semantics are identical everywhere. Child tokens
+    provide scoped cancellation (e.g. one monitoring batch) that also
+    fires when the parent stops.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._children: list[StopToken] = []
+        self._lock = threading.Lock()
+
+    def set(self) -> None:
+        """Request stop, propagating to child tokens."""
+        self._event.set()
+        with self._lock:
+            children = list(self._children)
+        for child in children:
+            child.set()
+
+    def is_set(self) -> bool:
+        """Return True if stop has been requested."""
+        return self._event.is_set()
+
+    def wait(self, delay: float) -> bool:
+        """Block for up to delay seconds.
+
+        Args:
+            delay: Maximum time to wait in seconds.
+
+        Returns:
+            True if the full delay elapsed, False if interrupted by stop.
+        """
+        return not self._event.wait(delay)
+
+    def raise_if_set(self) -> None:
+        """Raise when stop has been requested.
+
+        Raises:
+            StopRequestedError: If the token is set.
+        """
+        if self._event.is_set():
+            raise StopRequestedError("Stop requested")
+
+    def child(self) -> StopToken:
+        """Create a linked token that also stops when this one does."""
+        token = StopToken()
+        with self._lock:
+            self._children = [c for c in self._children if not c.is_set()]
+            self._children.append(token)
+        if self._event.is_set():
+            token.set()
+        return token

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ynu_xk_spider.app import parse_args
+
+
+def test_parse_args_accepts_explicit_argv() -> None:
+    args = parse_args(["--headless", "--log-level", "DEBUG", "-c", "custom.json"])
+
+    assert args.headless is True
+    assert args.log_level == "DEBUG"
+    assert args.config == Path("custom.json")
+
+
+def test_parse_args_defaults_are_isolated_from_process_argv() -> None:
+    args = parse_args([])
+
+    assert args.headless is False
+    assert args.log_level is None
+    assert args.config == Path("config.json")

--- a/tests/test_browser_manager_options.py
+++ b/tests/test_browser_manager_options.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import Any
 
 import pytest
 
 from ynu_xk_spider.browser.manager import BrowserManager
 from ynu_xk_spider.config import AppSettings
-
-
-@pytest.fixture(autouse=True)
-def _reset_browser_manager() -> Generator[None, None, None]:
-    BrowserManager.reset()
-    yield
-    BrowserManager.reset()
 
 
 class _FakeDriver:
@@ -43,7 +35,7 @@ def test_chrome_password_prompt_is_disabled(
     )
 
     settings = AppSettings(student_code="20230001", password="secret")
-    manager = BrowserManager.instance(settings)
+    manager = BrowserManager(settings)
 
     driver = manager.get_driver()
     assert driver is fake_driver

--- a/tests/test_browser_manager_options.py
+++ b/tests/test_browser_manager_options.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gc
+import weakref
 from typing import Any
 
 import pytest
@@ -11,12 +13,13 @@ from ynu_xk_spider.config import AppSettings
 class _FakeDriver:
     def __init__(self) -> None:
         self.cdp_calls: list[tuple[str, dict[str, Any]]] = []
+        self.quit_calls = 0
 
     def execute_cdp_cmd(self, method: str, payload: dict[str, Any]) -> None:
         self.cdp_calls.append((method, payload))
 
     def quit(self) -> None:
-        return None
+        self.quit_calls += 1
 
 
 def test_chrome_password_prompt_is_disabled(
@@ -53,3 +56,53 @@ def test_chrome_password_prompt_is_disabled(
 
     assert fake_driver.cdp_calls
     assert fake_driver.cdp_calls[0][0] == "Page.addScriptToEvaluateOnNewDocument"
+
+    manager_ref = weakref.ref(manager)
+    manager.shutdown()
+    assert fake_driver.quit_calls == 1
+
+    del manager
+    gc.collect()
+
+    assert manager_ref() is None
+
+
+def test_atexit_hook_follows_each_live_driver_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active_callbacks: list[Any] = []
+    drivers = [_FakeDriver(), _FakeDriver()]
+    driver_iter = iter(drivers)
+
+    def _register(callback: Any) -> Any:
+        active_callbacks.append(callback)
+        return callback
+
+    def _unregister(callback: Any) -> None:
+        active_callbacks.remove(callback)
+
+    monkeypatch.setattr("ynu_xk_spider.browser.manager.atexit.register", _register)
+    monkeypatch.setattr("ynu_xk_spider.browser.manager.atexit.unregister", _unregister)
+    monkeypatch.setattr(
+        "ynu_xk_spider.browser.manager.webdriver.Chrome",
+        lambda *args, **kwargs: next(driver_iter),
+    )
+
+    settings = AppSettings(student_code="20230001", password="secret")
+    manager = BrowserManager(settings)
+
+    assert active_callbacks == []
+
+    assert manager.get_driver() is drivers[0]
+    assert len(active_callbacks) == 1
+
+    manager.shutdown()
+    assert drivers[0].quit_calls == 1
+    assert active_callbacks == []
+
+    assert manager.get_driver() is drivers[1]
+    assert len(active_callbacks) == 1
+
+    manager.shutdown()
+    assert drivers[1].quit_calls == 1
+    assert active_callbacks == []

--- a/tests/test_config_courses.py
+++ b/tests/test_config_courses.py
@@ -40,3 +40,13 @@ def test_app_settings_load_rejects_missing_explicit_config(tmp_path: Path) -> No
 
     with pytest.raises(ConfigError):
         AppSettings.load(missing)
+
+
+def test_app_settings_rejects_inverted_poll_interval() -> None:
+    with pytest.raises(ValidationError):
+        AppSettings(
+            student_code="20230001",
+            password="secret",
+            poll_interval_min=10.0,
+            poll_interval_max=5.0,
+        )

--- a/tests/test_course_selector_async_notify.py
+++ b/tests/test_course_selector_async_notify.py
@@ -13,6 +13,7 @@ from ynu_xk_spider.domain.models import (
     SelectionResult,
 )
 from ynu_xk_spider.domain.services.course_selector import CourseSelector
+from ynu_xk_spider.domain.services.notification import AsyncNotifier
 from ynu_xk_spider.exceptions import CourseSelectionError, NetworkError
 from ynu_xk_spider.utils.stop import StopToken
 
@@ -90,9 +91,10 @@ class _PartialFailureApi(_FakeApi):
         return super().select_course(course, course_type)
 
 
-def test_notifications_are_async_and_flushed_on_wait() -> None:
+def test_notifications_are_async_and_flushed() -> None:
     settings = AppSettings(student_code="20230001", password="secret")
-    notifier = _SlowNotifier()
+    inner = _SlowNotifier()
+    notifier = AsyncNotifier(inner)
     api = _FakeApi()
     selector = CourseSelector(api=api, settings=settings, notifier=notifier)
     course = CourseItem(name="Linear Algebra", teacher="Prof. Li")
@@ -104,9 +106,40 @@ def test_notifications_are_async_and_flushed_on_wait() -> None:
     assert result is MonitorOutcome.SUCCESS
     assert elapsed < 0.2
 
-    selector.wait_for_notifications()
-    assert len(notifier.messages) == 2
+    notifier.flush()
+    assert len(inner.messages) == 2
     assert api.query_count == 1
+
+
+def test_async_notifier_is_reusable_after_flush() -> None:
+    inner = _SlowNotifier()
+    notifier = AsyncNotifier(inner)
+
+    notifier.send("first", "1")
+    notifier.flush()
+    notifier.send("second", "2")
+    notifier.flush()
+
+    assert [title for title, _ in inner.messages] == ["first", "second"]
+
+
+def test_async_notifier_skips_sending_when_disabled() -> None:
+    class _DisabledNotifier:
+        enabled = False
+
+        def __init__(self) -> None:
+            self.messages: list[tuple[str, str]] = []
+
+        def send(self, title: str, content: str) -> None:
+            self.messages.append((title, content))
+
+    inner = _DisabledNotifier()
+    notifier = AsyncNotifier(inner)
+
+    notifier.send("ignored", "x")
+    notifier.flush()
+
+    assert inner.messages == []
 
 
 def test_group_monitoring_queries_once_for_multiple_teachers() -> None:

--- a/tests/test_course_selector_async_notify.py
+++ b/tests/test_course_selector_async_notify.py
@@ -13,7 +13,7 @@ from ynu_xk_spider.domain.models import (
     SelectionResult,
 )
 from ynu_xk_spider.domain.services.course_selector import CourseSelector
-from ynu_xk_spider.domain.services.notification import AsyncNotifier
+from ynu_xk_spider.domain.services.notification import AsyncNotifier, ServerChanNotifier
 from ynu_xk_spider.exceptions import CourseSelectionError, NetworkError
 from ynu_xk_spider.utils.stop import StopToken
 
@@ -140,6 +140,17 @@ def test_async_notifier_skips_sending_when_disabled() -> None:
     notifier.flush()
 
     assert inner.messages == []
+
+
+def test_default_notifier_does_not_create_an_unowned_async_executor() -> None:
+    settings = AppSettings(
+        student_code="20230001",
+        password="secret",
+        server_chan_key="configured",
+    )
+    selector = CourseSelector(api=_FakeApi(), settings=settings)
+
+    assert isinstance(selector._notifier, ServerChanNotifier)
 
 
 def test_group_monitoring_queries_once_for_multiple_teachers() -> None:

--- a/tests/test_course_selector_async_notify.py
+++ b/tests/test_course_selector_async_notify.py
@@ -6,7 +6,12 @@ import time
 import pytest
 
 from ynu_xk_spider.config import AppSettings, CourseItem
-from ynu_xk_spider.domain.models import CourseInfo, MonitorOutcome, SelectionResult
+from ynu_xk_spider.domain.models import (
+    CourseInfo,
+    CourseType,
+    MonitorOutcome,
+    SelectionResult,
+)
 from ynu_xk_spider.domain.services.course_selector import CourseSelector
 from ynu_xk_spider.exceptions import CourseSelectionError, NetworkError
 
@@ -42,7 +47,7 @@ class _FakeApi:
             ),
         ]
 
-    def query_courses(self, course_name: str, course_type: str) -> list[CourseInfo]:
+    def query_courses(self, course_name: str, course_type: CourseType) -> list[CourseInfo]:
         self.query_count += 1
         return self.slots
 
@@ -53,7 +58,7 @@ class _FakeApi:
     ) -> list[CourseInfo]:
         return [c for c in courses if teacher_name in c.teacher_name]
 
-    def select_course(self, course: CourseInfo, course_type: str) -> SelectionResult:
+    def select_course(self, course: CourseInfo, course_type: CourseType) -> SelectionResult:
         return SelectionResult(
             success=True,
             message="选课成功",
@@ -67,7 +72,7 @@ class _FailingQueryApi(_FakeApi):
         super().__init__()
         self._exc = exc
 
-    def query_courses(self, course_name: str, course_type: str) -> list[CourseInfo]:
+    def query_courses(self, course_name: str, course_type: CourseType) -> list[CourseInfo]:
         self.query_count += 1
         raise self._exc
 
@@ -77,7 +82,7 @@ class _PartialFailureApi(_FakeApi):
         super().__init__()
         self.selection_attempts: dict[str, int] = {"Prof. Li": 0, "Prof. Wang": 0}
 
-    def select_course(self, course: CourseInfo, course_type: str) -> SelectionResult:
+    def select_course(self, course: CourseInfo, course_type: CourseType) -> SelectionResult:
         self.selection_attempts[course.teacher_name] += 1
         if course.teacher_name == "Prof. Wang" and self.selection_attempts[course.teacher_name] == 1:
             raise NetworkError("temporary selection failure")
@@ -92,7 +97,7 @@ def test_notifications_are_async_and_flushed_on_wait() -> None:
     course = CourseItem(name="Linear Algebra", teacher="Prof. Li")
 
     start = time.perf_counter()
-    result = selector.run_monitoring_loop(course, "素选", is_stopped=lambda: False)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=lambda: False)
     elapsed = time.perf_counter() - start
 
     assert result is MonitorOutcome.SUCCESS
@@ -110,7 +115,7 @@ def test_group_monitoring_queries_once_for_multiple_teachers() -> None:
 
     result = selector.run_group_monitoring_loop(
         course_name="Linear Algebra",
-        course_type="素选",
+        course_type=CourseType.PUBLIC,
         targets=[
             CourseItem(name="Linear Algebra", teacher="Prof. Li"),
             CourseItem(name="Linear Algebra", teacher="Prof. Wang"),
@@ -129,7 +134,7 @@ def test_group_monitoring_with_empty_targets_is_success() -> None:
 
     result = selector.run_group_monitoring_loop(
         course_name="Linear Algebra",
-        course_type="素选",
+        course_type=CourseType.PUBLIC,
         targets=[],
         is_stopped=lambda: False,
     )
@@ -150,7 +155,7 @@ def test_monitoring_wait_is_interruptible() -> None:
     course = CourseItem(name="Nonexistent", teacher="Nobody")
 
     class _NoResultApi(_FakeApi):
-        def query_courses(self, course_name: str, course_type: str) -> list[CourseInfo]:
+        def query_courses(self, course_name: str, course_type: CourseType) -> list[CourseInfo]:
             self.query_count += 1
             return []
 
@@ -164,7 +169,7 @@ def test_monitoring_wait_is_interruptible() -> None:
     stopper.start()
 
     start = time.perf_counter()
-    result = selector.run_monitoring_loop(course, "素选", is_stopped=stop_event.is_set)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=stop_event.is_set)
     elapsed = time.perf_counter() - start
     stopper.join()
 
@@ -196,7 +201,7 @@ def test_monitoring_retries_failures_until_threshold(
         lambda delay, is_stopped: wait_delays.append(delay) or True,
     )
 
-    result = selector.run_monitoring_loop(course, "素选", is_stopped=lambda: False)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=lambda: False)
 
     assert result is MonitorOutcome.FAILED
     assert api.query_count == 5
@@ -219,7 +224,7 @@ def test_group_monitoring_preserves_successful_targets_across_target_failure(
 
     result = selector.run_group_monitoring_loop(
         course_name="Linear Algebra",
-        course_type="素选",
+        course_type=CourseType.PUBLIC,
         targets=[
             CourseItem(name="Linear Algebra", teacher="Prof. Li"),
             CourseItem(name="Linear Algebra", teacher="Prof. Wang"),

--- a/tests/test_course_selector_async_notify.py
+++ b/tests/test_course_selector_async_notify.py
@@ -14,6 +14,7 @@ from ynu_xk_spider.domain.models import (
 )
 from ynu_xk_spider.domain.services.course_selector import CourseSelector
 from ynu_xk_spider.exceptions import CourseSelectionError, NetworkError
+from ynu_xk_spider.utils.stop import StopToken
 
 
 class _SlowNotifier:
@@ -97,7 +98,7 @@ def test_notifications_are_async_and_flushed_on_wait() -> None:
     course = CourseItem(name="Linear Algebra", teacher="Prof. Li")
 
     start = time.perf_counter()
-    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=lambda: False)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, stop=StopToken())
     elapsed = time.perf_counter() - start
 
     assert result is MonitorOutcome.SUCCESS
@@ -120,7 +121,7 @@ def test_group_monitoring_queries_once_for_multiple_teachers() -> None:
             CourseItem(name="Linear Algebra", teacher="Prof. Li"),
             CourseItem(name="Linear Algebra", teacher="Prof. Wang"),
         ],
-        is_stopped=lambda: False,
+        stop=StopToken(),
     )
 
     assert result is MonitorOutcome.SUCCESS
@@ -136,7 +137,7 @@ def test_group_monitoring_with_empty_targets_is_success() -> None:
         course_name="Linear Algebra",
         course_type=CourseType.PUBLIC,
         targets=[],
-        is_stopped=lambda: False,
+        stop=StopToken(),
     )
 
     assert result is MonitorOutcome.SUCCESS
@@ -151,7 +152,7 @@ def test_monitoring_wait_is_interruptible() -> None:
         poll_interval_max=1.0,
     )
     selector = CourseSelector(api=_FakeApi(), settings=settings)
-    stop_event = threading.Event()
+    stop = StopToken()
     course = CourseItem(name="Nonexistent", teacher="Nobody")
 
     class _NoResultApi(_FakeApi):
@@ -163,13 +164,13 @@ def test_monitoring_wait_is_interruptible() -> None:
 
     def _trigger_stop() -> None:
         time.sleep(0.05)
-        stop_event.set()
+        stop.set()
 
     stopper = threading.Thread(target=_trigger_stop)
     stopper.start()
 
     start = time.perf_counter()
-    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=stop_event.is_set)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, stop=stop)
     elapsed = time.perf_counter() - start
     stopper.join()
 
@@ -198,10 +199,10 @@ def test_monitoring_retries_failures_until_threshold(
     monkeypatch.setattr(
         selector,
         "_wait_with_stop",
-        lambda delay, is_stopped: wait_delays.append(delay) or True,
+        lambda delay, stop: wait_delays.append(delay) or True,
     )
 
-    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, is_stopped=lambda: False)
+    result = selector.run_monitoring_loop(course, CourseType.PUBLIC, stop=StopToken())
 
     assert result is MonitorOutcome.FAILED
     assert api.query_count == 5
@@ -219,7 +220,7 @@ def test_group_monitoring_preserves_successful_targets_across_target_failure(
     monkeypatch.setattr(
         selector,
         "_wait_with_stop",
-        lambda delay, is_stopped: wait_delays.append(delay) or True,
+        lambda delay, stop: wait_delays.append(delay) or True,
     )
 
     result = selector.run_group_monitoring_loop(
@@ -229,7 +230,7 @@ def test_group_monitoring_preserves_successful_targets_across_target_failure(
             CourseItem(name="Linear Algebra", teacher="Prof. Li"),
             CourseItem(name="Linear Algebra", teacher="Prof. Wang"),
         ],
-        is_stopped=lambda: False,
+        stop=StopToken(),
     )
 
     assert result is MonitorOutcome.SUCCESS

--- a/tests/test_course_type.py
+++ b/tests/test_course_type.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ynu_xk_spider.config import CourseItem, CoursesConfig
+from ynu_xk_spider.domain.models import (
+    CourseTarget,
+    CourseType,
+    QueryRequest,
+    SelectionRequest,
+)
+from ynu_xk_spider.domain.services.course_api import CourseApiClient
+
+
+def test_course_type_carries_api_mapping() -> None:
+    assert CourseType.PUBLIC.class_type_code == "XGXK"
+    assert CourseType.PROGRAM.class_type_code == "FANKC"
+    assert CourseType.PE.class_type_code == "TYKC"
+    assert CourseType.PUBLIC.nested_response is False
+    assert CourseType.PROGRAM.nested_response is True
+    assert CourseType.PE.nested_response is True
+    assert str(CourseType.PUBLIC) == "素选"
+    assert [course_type.label for course_type in CourseType] == ["素选", "主修", "体育"]
+
+
+def test_all_courses_returns_targets_in_category_order() -> None:
+    config = CoursesConfig(
+        public=[CourseItem(name="A", teacher="T1")],
+        program=[CourseItem(name="B", teacher="T2")],
+        pe=[CourseItem(name="C", teacher="T3")],
+    )
+
+    targets = config.all_courses
+
+    assert targets == [
+        CourseTarget(CourseItem(name="A", teacher="T1"), CourseType.PUBLIC),
+        CourseTarget(CourseItem(name="B", teacher="T2"), CourseType.PROGRAM),
+        CourseTarget(CourseItem(name="C", teacher="T3"), CourseType.PE),
+    ]
+    assert targets[0].item.name == "A"
+    assert targets[0].course_type is CourseType.PUBLIC
+
+
+def _api() -> CourseApiClient:
+    return CourseApiClient(
+        http=None,  # type: ignore[arg-type]
+        base_url="https://xk.example.invalid/",
+        student_code="20230001",
+        batch_code="batch-1",
+        campus="02",
+    )
+
+
+def test_parse_course_list_flat_for_public() -> None:
+    data = {"dataList": [{"teachingClassID": "c1", "classCapacity": 10}]}
+
+    courses = _api()._parse_course_list(data, CourseType.PUBLIC)
+
+    assert [course.teaching_class_id for course in courses] == ["c1"]
+
+
+@pytest.mark.parametrize("course_type", [CourseType.PROGRAM, CourseType.PE])
+def test_parse_course_list_nested_for_program_and_pe(course_type: CourseType) -> None:
+    data = {"dataList": [{"tcList": [{"teachingClassID": "c2"}]}]}
+
+    courses = _api()._parse_course_list(data, course_type)
+
+    assert [course.teaching_class_id for course in courses] == ["c2"]
+
+
+def test_request_models_require_explicit_campus() -> None:
+    with pytest.raises(ValidationError):
+        SelectionRequest(  # type: ignore[call-arg]
+            student_code="s",
+            batch_code="b",
+            teaching_class_id="t",
+            class_type="XGXK",
+        )
+    with pytest.raises(ValidationError):
+        QueryRequest(  # type: ignore[call-arg]
+            student_code="s",
+            batch_code="b",
+            class_type="XGXK",
+            query_content="q",
+        )

--- a/tests/test_http_client_thread_local.py
+++ b/tests/test_http_client_thread_local.py
@@ -28,13 +28,16 @@ class _FakeSession:
         self.should_fail = should_fail
         self.closed = False
 
-    def get(self, url: str, **kwargs: Any) -> Any:
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
         if self.should_fail:
             raise requests.RequestException("boom")
-        raise AssertionError("GET should not be called in this test")
+        raise AssertionError("No real request expected in this test")
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        raise AssertionError("Client must go through Session.request")
 
     def post(self, url: str, **kwargs: Any) -> Any:
-        raise AssertionError("POST should not be called in this test")
+        raise AssertionError("Client must go through Session.request")
 
     def close(self) -> None:
         self.closed = True

--- a/tests/test_http_client_thread_local.py
+++ b/tests/test_http_client_thread_local.py
@@ -10,6 +10,7 @@ import requests
 from ynu_xk_spider.config import AppSettings
 from ynu_xk_spider.exceptions import NetworkError
 from ynu_xk_spider.http.client import HttpClient
+from ynu_xk_spider.utils.stop import StopToken
 
 
 class _FakeCookies:
@@ -77,7 +78,7 @@ def test_http_client_uses_thread_local_sessions(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_http_client_retry_backoff_is_interruptible(monkeypatch: pytest.MonkeyPatch) -> None:
-    stop_event = threading.Event()
+    stop = StopToken()
 
     def _build_session() -> _FakeSession:
         return _FakeSession(should_fail=True)
@@ -92,13 +93,13 @@ def test_http_client_retry_backoff_is_interruptible(monkeypatch: pytest.MonkeyPa
             retry_backoff=1.0,
             retry_factor=1.0,
         ),
-        stop_event=stop_event,
+        stop=stop,
     )
     client.set_auth("token", {"SESSION": "abc"})
 
     def _trigger_stop() -> None:
         time.sleep(0.05)
-        stop_event.set()
+        stop.set()
 
     stopper = threading.Thread(target=_trigger_stop)
     stopper.start()

--- a/tests/test_login_service_batch_dialog.py
+++ b/tests/test_login_service_batch_dialog.py
@@ -13,6 +13,7 @@ from selenium.webdriver.common.by import By
 from ynu_xk_spider.config import AppSettings
 from ynu_xk_spider.domain.services.login import LoginService
 from ynu_xk_spider.exceptions import StopRequestedError
+from ynu_xk_spider.utils.stop import StopToken
 
 
 class _DummyBrowser:
@@ -229,28 +230,25 @@ def test_open_course_selection_page_retries_when_course_button_missing(monkeypat
         "_prepare_for_start_button_click",
         lambda _: None,
     )
-    monkeypatch.setattr(
-        "ynu_xk_spider.domain.services.login.time.sleep",
-        lambda _: None,
-    )
+    monkeypatch.setattr(service, "_wait_or_stop", lambda _delay: None)
 
     assert service._open_course_selection_page(driver) is False
     assert driver.find_attempts == service.MAX_START_BUTTON_ATTEMPTS
 
 
 def test_wait_or_stop_is_interruptible() -> None:
-    stop_event = threading.Event()
+    stop = StopToken()
     settings = AppSettings(student_code="20230001", password="secret")
     service = LoginService(
         settings,
         _DummyBrowser(),
         _DummySolver(),
-        is_stopped=stop_event.is_set,
+        stop=stop,
     )
 
     def _trigger_stop() -> None:
         time.sleep(0.05)
-        stop_event.set()
+        stop.set()
 
     stopper = threading.Thread(target=_trigger_stop)
     stopper.start()

--- a/tests/test_spider_resilience.py
+++ b/tests/test_spider_resilience.py
@@ -9,6 +9,7 @@ from ynu_xk_spider.config import AppSettings, CourseItem, CoursesConfig
 from ynu_xk_spider.domain.models import CourseType, MonitorOutcome, SessionData
 from ynu_xk_spider.exceptions import LoginError, StopRequestedError
 from ynu_xk_spider.spiders.ynu_spider import YnuCourseSpider
+from ynu_xk_spider.utils.stop import StopToken
 
 
 @pytest.fixture(autouse=True)
@@ -100,7 +101,7 @@ def test_run_monitoring_returns_stopped_for_manual_stop() -> None:
     assert spider._run_monitoring(_StoppedSelector()) is MonitorOutcome.STOPPED
 
 
-def test_perform_login_reuses_solver_and_stop_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_perform_login_reuses_solver_and_stop_token(monkeypatch: pytest.MonkeyPatch) -> None:
     spider = YnuCourseSpider(_build_settings())
     observed_solver_ids: list[int] = []
     observed_stop_values: list[bool] = []
@@ -111,10 +112,10 @@ def test_perform_login_reuses_solver_and_stop_callback(monkeypatch: pytest.Monke
             settings: AppSettings,
             browser: BrowserManager,
             solver: object,
-            is_stopped: object,
+            stop: StopToken,
         ) -> None:
             observed_solver_ids.append(id(solver))
-            observed_stop_values.append(bool(is_stopped()))
+            observed_stop_values.append(stop.is_set())
 
         def login(self) -> SessionData:
             return SessionData(cookies={"SESSION": "abc"}, token="token", batch_code="batch")

--- a/tests/test_spider_resilience.py
+++ b/tests/test_spider_resilience.py
@@ -6,7 +6,7 @@ import pytest
 
 from ynu_xk_spider.browser.manager import BrowserManager
 from ynu_xk_spider.config import AppSettings, CourseItem, CoursesConfig
-from ynu_xk_spider.domain.models import MonitorOutcome, SessionData
+from ynu_xk_spider.domain.models import CourseType, MonitorOutcome, SessionData
 from ynu_xk_spider.exceptions import LoginError, StopRequestedError
 from ynu_xk_spider.spiders.ynu_spider import YnuCourseSpider
 
@@ -65,7 +65,7 @@ def test_group_course_targets_merges_same_name_and_type() -> None:
     assert grouped == [
         (
             "Linear Algebra",
-            "素选",
+            CourseType.PUBLIC,
             [
                 CourseItem(name="Linear Algebra", teacher="Prof. Li"),
                 CourseItem(name="Linear Algebra", teacher="Prof. Wang"),
@@ -73,7 +73,7 @@ def test_group_course_targets_merges_same_name_and_type() -> None:
         ),
         (
             "Swimming",
-            "体育",
+            CourseType.PE,
             [CourseItem(name="Swimming", teacher="Coach Lin")],
         ),
     ]

--- a/tests/test_spider_resilience.py
+++ b/tests/test_spider_resilience.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-
 import pytest
 
 from ynu_xk_spider.browser.manager import BrowserManager
@@ -10,13 +8,6 @@ from ynu_xk_spider.domain.models import CourseType, MonitorOutcome, SessionData
 from ynu_xk_spider.exceptions import LoginError, StopRequestedError
 from ynu_xk_spider.spiders.ynu_spider import YnuCourseSpider
 from ynu_xk_spider.utils.stop import StopToken
-
-
-@pytest.fixture(autouse=True)
-def _reset_browser_manager() -> Generator[None, None, None]:
-    BrowserManager.reset()
-    yield
-    BrowserManager.reset()
 
 
 def _build_settings() -> AppSettings:

--- a/tests/test_spider_resilience.py
+++ b/tests/test_spider_resilience.py
@@ -86,9 +86,6 @@ def test_run_monitoring_returns_stopped_for_manual_stop() -> None:
         def run_group_monitoring_loop(self, *args: object, **kwargs: object) -> MonitorOutcome:
             return MonitorOutcome.STOPPED
 
-        def wait_for_notifications(self, timeout: float | None = None) -> None:
-            return None
-
     assert spider._run_monitoring(_StoppedSelector()) is MonitorOutcome.STOPPED
 
 

--- a/tests/test_stop_token.py
+++ b/tests/test_stop_token.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from ynu_xk_spider.exceptions import StopRequestedError
+from ynu_xk_spider.utils.stop import StopToken
+
+
+def test_wait_returns_true_when_delay_elapses() -> None:
+    token = StopToken()
+    assert token.wait(0.01) is True
+
+
+def test_wait_is_interrupted_by_set() -> None:
+    token = StopToken()
+    threading.Timer(0.05, token.set).start()
+
+    start = time.perf_counter()
+    assert token.wait(5.0) is False
+    assert time.perf_counter() - start < 0.5
+
+
+def test_raise_if_set() -> None:
+    token = StopToken()
+    token.raise_if_set()
+
+    token.set()
+    with pytest.raises(StopRequestedError):
+        token.raise_if_set()
+
+
+def test_child_stops_with_parent_but_not_vice_versa() -> None:
+    parent = StopToken()
+    child = parent.child()
+
+    child.set()
+    assert not parent.is_set()
+
+    sibling = parent.child()
+    parent.set()
+    assert sibling.is_set()
+
+
+def test_child_of_already_stopped_parent_is_set() -> None:
+    parent = StopToken()
+    parent.set()
+    assert parent.child().is_set()

--- a/tests/test_stop_token.py
+++ b/tests/test_stop_token.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import gc
 import threading
 import time
+import weakref
 
 import pytest
 
@@ -48,3 +50,36 @@ def test_child_of_already_stopped_parent_is_set() -> None:
     parent = StopToken()
     parent.set()
     assert parent.child().is_set()
+
+
+def test_unreferenced_child_can_be_garbage_collected() -> None:
+    parent = StopToken()
+    child = parent.child()
+    child_ref = weakref.ref(child)
+
+    del child
+    gc.collect()
+
+    assert child_ref() is None
+
+
+def test_live_descendant_keeps_stop_propagation_chain_alive() -> None:
+    parent = StopToken()
+    grandchild = parent.child().child()
+
+    gc.collect()
+    parent.set()
+
+    assert grandchild.is_set()
+
+
+def test_stopped_child_releases_its_parent() -> None:
+    parent = StopToken()
+    child = parent.child()
+    parent_ref = weakref.ref(parent)
+
+    child.set()
+    del parent
+    gc.collect()
+
+    assert parent_ref() is None


### PR DESCRIPTION
## PR Description

  ## Overview

  This PR restructures several core components of the course-selection workflow. It consolidates course-type mappings,
  cancellation semantics, notification handling, browser lifecycle ownership, and HTTP request logic.

  The refactor preserves existing public APIs and primary runtime behavior while reducing duplicated logic, implicit
  state, and overlapping responsibilities.

  ## Key Changes

  ### 1. Dead Code and Quality Baseline Cleanup

  - Removed four unused code paths
  - Removed the Pydantic v1 compatibility shim and adopted `model_copy`
  - Removed obsolete `type: ignore` comments
  - Resolved the existing Ruff and strict mypy baseline issues

  ### 2. Centralized Course-Type Mapping

  Introduced a `CourseType` enum to consolidate mappings previously duplicated across three locations:

  - API endpoints
  - `teachingClassType` codes
  - Response nesting structures

  `CoursesConfig.all_courses` now returns typed `CourseTarget` objects. The silent fallback to `XGXK` for unknown
  course types has also been removed.

  ### 3. Unified Cancellation with `StopToken`

  Introduced `StopToken` to replace the layered `Callable[[], bool]` cancellation callbacks:

  - Provides consistent stop checks, interruptible waits, and exception semantics
  - Supports parent-child token propagation
  - Allows batch cancellation without stopping the global token
  - Removes three custom 0.1-second polling loops

  ### 4. Explicit Browser Lifecycle Ownership

  Removed the `BrowserManager` singleton:

  - `BrowserManager` is now created normally and injected where needed
  - `LoginService` no longer closes the browser as a hidden side effect
  - Browser shutdown is owned by `YnuCourseSpider`
  - Success, failure, and cancellation paths now converge on a single `finally` cleanup path

  ### 5. Extracted Notification Services

  Added `notification.py` with:

  - A `Notifier` protocol
  - The synchronous `ServerChanNotifier`
  - A reusable `AsyncNotifier`
  - Explicit notifier flushing owned by the spider

  `CourseSelector` now only calls `send()`, removing approximately 60 lines of notification-thread management from
  `course_selector.py`.

  ### 6. Consolidated HTTP Request Logic

  Merged the duplicated `HttpClient.get()` and `post()` implementations into a shared `_request()` method:

  - Uses `requests.Session.request`
  - Constructs and reuses the retry decorator once during initialization
  - Preserves the existing public `get()` and `post()` signatures

  ### 7. Configuration and CLI Corrections

  - `poll_interval_min > poll_interval_max` now raises `ConfigError`
  - Invalid interval bounds are no longer silently swapped
  - `parse_args()` and `main()` now accept an explicit argument list
  - Programmatic calls such as `main([])` no longer read unrelated process arguments

  ### 8. Documentation Updates

  The README has been updated to match the implementation:

  - Project structure
  - Architecture diagram
  - Design-pattern table
  - `StopToken` cancellation flow
  - Notification lifecycle
  - Actual test count

  ## Intentional Behavior Changes

  1. An inverted polling interval now raises `ConfigError` instead of being silently corrected.
  2. Programmatic callers can pass an explicit argument list to `main()`, fully isolating it from process-level
  `argv`.

  ## Validation

  - Test count increased from 27 to **43**, with all tests passing
  - Test runtime decreased from approximately **10.9s to 7.8–8.3s**
  - `ruff check .`: **passed with zero errors**
  - `mypy src` in strict mode: **passed with zero errors**
  - `python -m ynu_xk_spider --help`: **smoke test passed**
  - Public APIs such as `HttpClient.get()` and `post()`: **unchanged**

  New test coverage includes:

  - `CourseType` enum mappings
  - `StopToken` interruption and parent-child propagation
  - `AsyncNotifier` lifecycle and reuse
  - CLI argument isolation
  - Polling interval validation

  ## Code Size Note

  This refactor consolidates several duplicated implementations:

  - Three interruptible-wait implementations → one `StopToken`
  - Three course-category mappings → one `CourseType`
  - Two HTTP request paths → one `_request()` method

  However, the expected net deletion of 150–250 lines was not achieved. The new `stop.py` and `notification.py`
  modules include complete documentation following the project's Google-style docstring conventions.

  As a result, the source code increased from 3,036 to 3,129 lines (+93). The main benefit of this PR is therefore
  simpler responsibilities, reduced duplication, and clearer lifecycle management rather than a lower total line
  count.